### PR TITLE
Chore: allow system input to be overriden

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,7 +5,9 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems"
+        "systems": [
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1724053269,
@@ -40,7 +42,8 @@
     "root": {
       "inputs": {
         "blueprint": "blueprint",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,9 @@
     nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
     blueprint.url = "github:numtide/blueprint";
     blueprint.inputs.nixpkgs.follows = "nixpkgs";
+
+    systems.url = "github:nix-systems/default";
+    blueprint.inputs.systems.follows = "systems";
   };
 
   # Load the blueprint


### PR DESCRIPTION
This allows downstream projects to override the "systems" input.

```nix
    hwinfo.url = "github:numtide/hwinfo";
    hwinfo.inputs.nixpkgs.follows = "nixpkgs";
    # Makes this possible
    hwinfo.inputs.systems.follows = "systems";
```

cc @brianmcgee 